### PR TITLE
Git Basic Commands

### DIFF
--- a/git-commands/commit.md
+++ b/git-commands/commit.md
@@ -1,0 +1,17 @@
+### Git commit related commands
+
+stage all the changes in your current working directory
+
+    git add .
+
+commit staged changes followed by a commit message prompt
+
+    git commit
+
+commit all changes in working directory followed by a commit message prompt
+
+    git commit -a
+
+commit staged changes in your repository with a message
+
+    git commit -m “<COMMIT_MESSAGE>”

--- a/git-commands/garbage-collection.md
+++ b/git-commands/garbage-collection.md
@@ -1,0 +1,18 @@
+### Git garbage collection related commands
+
+---
+    git fsck
+
+---
+
+    git gc
+
+---
+
+    git gc --auto
+
+---
+
+    git gc --prune=<DATE>
+
+---

--- a/git-commands/log.md
+++ b/git-commands/log.md
@@ -1,0 +1,4 @@
+### Git logging related commands
+
+    git log
+

--- a/git-commands/push.md
+++ b/git-commands/push.md
@@ -1,0 +1,13 @@
+### Git push related commands
+
+push BRANCH to the REMOTE repository
+
+    git push <REMOTE> <BRANCH>
+
+push all branches
+
+    git push --all <REMOTE>
+
+sets the remote branch as the upstream, making future pushes simpler
+    
+    git push -u <remote> <branch>

--- a/git-commands/rebase.md
+++ b/git-commands/rebase.md
@@ -1,0 +1,27 @@
+### Git rebase related commands
+
+---
+
+    git checkout feature-branch
+    git rebase main
+
+---
+
+    git rebase --onto newbase oldbase feature
+
+---
+
+    git rebase -i HEAD~n
+
+    edit <commit-hash> Commit message 1
+    edit <commit-hash> Commit message 2
+
+    git commit --amend --author="New Author Name <new-author-email@example.com>"
+
+    git rebase --continue
+    git rebase --abort
+    git rebase --skip
+
+    git push --force origin your-branch-name
+
+---

--- a/git-commands/signing-commits-and-git-configurations.md
+++ b/git-commands/signing-commits-and-git-configurations.md
@@ -1,0 +1,40 @@
+### Signing Commits and Git Configurations
+
+---
+
+    git config user.name "Your Name"
+    git config user.email "your.email@example.com"
+    git config --global user.name "Your Name"
+    git config --global user.email "your.email@example.com"
+
+---
+
+	git config user.name
+	git config user.email
+	git config --global user.name
+	git config --global user.email
+	git config --get user.signingkey
+	git config --get commit.gpgSign
+
+---
+
+	gpg --full-generate-key
+	gpg --list-secret-keys --keyid-format LONG
+	gpg --armor --export <YOUR_KEY_ID>
+	gpgconf --kill gpg-agent
+	gpgconf --launch gpg-agent
+
+---
+
+	git config --global user.signingkey <YOUR_KEY_ID>
+	git config --global commit.gpgSign true
+	git config user.signingkey ABC123DEF
+	git config commit.gpgSign true
+
+---
+
+	git commit -S -m "Your commit message"
+	git tag -s v1.0 -m "Version 1.0"
+	git log --show-signature
+
+---

--- a/git-commands/worktree-related.md
+++ b/git-commands/worktree-related.md
@@ -1,0 +1,15 @@
+### Git worktree related commands
+
+---
+
+    git worktree list
+
+---
+
+    git worktree add <PATH> <BRANCH_NAME>
+
+---
+
+    git worktree remove <PATH>
+
+---


### PR DESCRIPTION
# Git Basic Commands

## Details:

This pull request adds documentation for various Git commands, organizing them into different categories for better clarity and usability. The most important changes include the addition of sections for commit-related commands, garbage collection commands, logging commands, push commands, rebase commands, signing commits and configurations, and worktree-related commands.

Related Issues:
- #6 

## Modifications:

New sections added to documentation:

* [`git-commands/commit.md`](diffhunk://#diff-a2620c070248f57b0d13c11d2053dea288240a67b49b383892bd500ad63df6efR1-R17): Added a section for Git commit-related commands, including `git add .`, `git commit`, `git commit -a`, and `git commit -m "<COMMIT_MESSAGE>"`.
* [`git-commands/garbage-collection.md`](diffhunk://#diff-6ed738c7ffff9d567eb24056232b531aca8dc170dd3e7dc7379afd8fd5a813c6R1-R18): Added a section for Git garbage collection-related commands, including `git fsck`, `git gc`, `git gc --auto`, and `git gc --prune=<DATE>`.
* [`git-commands/log.md`](diffhunk://#diff-c06b2ef9835704cacdb01e558e38ae25e577033e6c6374b034fbae0d68ac790eR1-R4): Added a section for Git logging-related commands, including `git log`.
* [`git-commands/push.md`](diffhunk://#diff-f63e42440237dae5f8d89eae08dcf7e66566084d1ecd144b5443418106d48c17R1-R13): Added a section for Git push-related commands, including `git push <REMOTE> <BRANCH>`, `git push --all <REMOTE>`, and `git push -u <remote> <branch>`.
* [`git-commands/rebase.md`](diffhunk://#diff-22f8f376d44b61062d4b550f0da72c5b014b04ec828a840cec02e797fc44938aR1-R27): Added a section for Git rebase-related commands, including `git rebase`, `git rebase --onto`, `git rebase -i`, `git rebase --continue`, `git rebase --abort`, and `git rebase --skip`.
* [`git-commands/signing-commits-and-git-configurations.md`](diffhunk://#diff-950763dbcc243e89eba7580b766aeeb813a20087482d8c42ce882b57e3611636R1-R40): Added a section for signing commits and Git configurations, including `git config` commands and GPG key management commands.
* [`git-commands/worktree-related.md`](diffhunk://#diff-7044857642884bb92b3f45134ce6989221403e0fc986bd80b94d42ffe57644a1R1-R15): Added a section for Git worktree-related commands, including `git worktree list`, `git worktree add`, and `git worktree remove`.