### PR TITLE
Add osgi console commands

### DIFF
--- a/osgi-commands/osgi-console.md
+++ b/osgi-commands/osgi-console.md
@@ -1,0 +1,44 @@
+### OSGI console commands
+
+List down the bundles in the server with bundle id
+
+    ss
+ 
+Search the given name in the bundle and list it out
+
+    ss <NAME>
+
+List down services
+
+    ls
+
+Show bundle info
+
+    b <ID>
+
+Show unsatisfied constraints of the bundle
+
+    diag <ID>
+
+Start/Stop a bundle
+
+    start <ID>
+    stop <ID>
+
+
+Remove installed bundle
+
+    uninstall <ID>
+
+All registered services
+
+    services
+
+Detailed info about specific service
+
+    inspect service <SERVICE_NAME>
+ 
+
+Installing a bundle
+
+    install file:<FULL_PATH_TO_JAR>


### PR DESCRIPTION
# Add OSGI Console Commands

This pull request adds documentation for OSGI console commands to the `osgi-commands/osgi-console.md` file. The new 
section includes descriptions and examples of various commands used to interact with OSGI bundles and services.

### Details:

Related Issues:
- #8 



### Documentation additions:

* Added a new section titled "OSGI console commands" to `osgi-commands/osgi-console.md`, detailing commands for listing bundles, searching for bundles by name, listing services, showing bundle information, diagnosing bundle constraints, starting/stopping bundles, uninstalling bundles, listing all registered services, inspecting specific services, and installing bundles.