### PR TITLE
Add ESBs to Tech Catalog

### DIFF
--- a/tech-catalog/TechCatalog.md
+++ b/tech-catalog/TechCatalog.md
@@ -1,0 +1,7 @@
+# Technology Catalog
+
+## ESB: Enterprise Service Bus
+- Apache Synapse ESB
+- WSO2 Micro Integrator
+  - Microservices
+  - ESB (Centralized)

--- a/tech-catalog/esb/apache-synapse.md
+++ b/tech-catalog/esb/apache-synapse.md
@@ -1,0 +1,88 @@
+# Apache Synapse ESB
+
+[Apache Synapse documentation](http://synapse.apache.org/)
+
+`an open-source Enterprise Service Bus (ESB)` | `mediation framework` 
+* facilitates communication between different applications in a `SOA` (service-oriented architecture). 
+* lightweight and flexible platform for integrating and managing various services enabling 
+  * interoperability and 
+  * seamless data exchange
+
+### Use Cases
+
+- Service Integration
+- Message Transformation
+- Routing and Load Balancing
+
+### Key Features of Apache Synapse ESB
+
+1. **Message Mediation:**
+    - message formats supported: `SOAP`, `REST`, `JSON`, `XML`
+    - message transformation
+    - message routing
+    - message filtering
+
+2. **Service Orchestration:**
+    - aggregates multiple web services into a single service
+    - complex workflows  
+    - service chaining
+
+3. **Protocol and Data Transformation:**
+    - messages transformation between: `HTTP`, `JMS`, `SMTP` ...
+    - data formats conversion
+
+4. **Security:**
+    - `SSL/TLS` | `WS-Security` | `OAuth`
+    - authentication | authorization | encryption
+
+5. **Scalability and Performance:**
+    - high performance design 
+    - can handle a large number of concurrent messages
+    - clustering
+    - load balancing 
+
+6. **Extensibility:**
+    - custom mediators and connectors
+    - integration with other Apache projects like `Apache Axis2` and `Apache CXF`.
+
+### Example Configuration
+
+Example of an Apache Synapse configuration that routes messages based on their content:
+
+```xml
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <proxy name="SimpleStockQuoteProxy" transports="http">
+        <target>
+            <inSequence>
+                <log level="full"/>
+                <filter source="$body/stockSymbol" regex="IBM">
+                    <send>
+                        <endpoint>
+                            <address uri="http://example.com/IBMStockQuoteService"/>
+                        </endpoint>
+                    </send>
+                </filter>
+                <filter source="$body/stockSymbol" regex="GOOG">
+                    <send>
+                        <endpoint>
+                            <address uri="http://example.com/GoogleStockQuoteService"/>
+                        </endpoint>
+                    </send>
+                </filter>
+            </inSequence>
+            <outSequence>
+                <send/>
+            </outSequence>
+        </target>
+    </proxy>
+</definitions>
+```
+
+- **Proxy Service:** Defines a proxy named `SimpleStockQuoteProxy` that listens for HTTP requests.
+- **In Sequence:** Logs incoming messages and uses filters to route messages based on the `stockSymbol` element in the message body.
+    - If the `stockSymbol` is "IBM", the message is sent to the IBM Stock Quote Service.
+    - If the `stockSymbol` is "GOOG", the message is sent to the Google Stock Quote Service.
+- **Out Sequence:** Forwards the response back to the client.
+
+
+

--- a/tech-catalog/esb/wso2-mi.md
+++ b/tech-catalog/esb/wso2-mi.md
@@ -1,0 +1,87 @@
+# WSO2 Micro Integrator 
+
+[WSO2 Micro Integrator documentation](https://mi.docs.wso2.com/en/latest/).
+
+`lightweight and container-friendly integration runtime designed for microservices architectures`
+
+* part of the WSO2 Enterprise Integrator suite 
+* a robust platform for building, deploying, and managing integration solutions in cloud-native environments
+
+### Use Cases
+
+- Service Integration
+- API Management
+- Data Transformation
+- Event-Driven Architecture
+
+
+### Key Features of WSO2 Micro Integrator
+
+1. **Lightweight and Container-Friendly:**
+    - optimized for deployment in `Docker`, `Kubernetes`, and other containerized environments
+    - small footprint --> suitable for microservices architectures
+
+2. **Comprehensive Mediation Capabilities:**
+    - message routing
+    - message transformation
+    - message enhancement
+    - wide range of built-in mediators for various integration tasks
+
+3. **Supports Multiple Integration Patterns:**
+    - facilitates various `EIPs` (enterprise integration patterns)  
+         - content-based routing
+         - message transformation 
+         - service orchestration
+    - can be used to implement complex integration scenarios
+
+4. **Seamless Connectivity:**
+    - wide range of protocols and data formats  
+      -  `HTTP`, `HTTPS`, `JMS`, `SOAP`, `REST`, `JSON`, `XML`
+    - connectors for various third-party systems and cloud services
+
+5. **High Availability and Scalability:**
+    - support high availability through **clustering** and **failover mechanisms**
+    - scalable to handle varying loads and large volumes of data
+
+6. **DevOps Friendly:**
+    - integrates well with CI/CD pipelines for automated deployment and testing
+    - monitoring and management capabilities 
+      - via tools like `Prometheus` and `Grafana`
+
+### Example Configuration
+
+Example of a WSO2 Micro Integrator configuration that routes messages based on the content of the message:
+
+```xml
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <sequence name="main">
+        <log level="full">
+            <property name="Message" value="Routing based on content"/>
+        </log>
+        <filter source="$body/stockSymbol" regex="WSO2">
+            <then>
+                <send>
+                    <endpoint>
+                        <address uri="http://example.com/WSO2StockQuoteService"/>
+                    </endpoint>
+                </send>
+            </then>
+            <else>
+                <send>
+                    <endpoint>
+                        <address uri="http://example.com/DefaultStockQuoteService"/>
+                    </endpoint>
+                </send>
+            </else>
+        </filter>
+    </sequence>
+</definitions>
+```
+
+- **Sequence:** Defines a sequence named `main` that will handle incoming messages.
+- **Logging:** Logs the message with a custom property to indicate that routing is based on content.
+- **Filter:** Uses a filter mediator to check the `stockSymbol` element in the message body.
+    - If the `stockSymbol` is "WSO2", the message is routed to the WSO2 Stock Quote Service.
+    - If the `stockSymbol` is not "WSO2", the message is routed to the Default Stock Quote Service.
+
+


### PR DESCRIPTION
# Add ESBs to Tech Catalog

This pull request adds detailed documentation for two Enterprise Service Bus (ESB) technologies, Apache Synapse ESB and WSO2 Micro Integrator, to the technology catalog. The changes include an overview of each technology, their use cases, key features, and example configurations.

### Details:

Related Issues:
- #12 

### Documentation additions:

* [`tech-catalog/TechCatalog.md`](diffhunk://#diff-65eb14c613eedd617bafb5db4d5efb69c881a346fc2258e5938bdbdf73e23611R1-R7): Added a new section for ESB with entries for Apache Synapse ESB and WSO2 Micro Integrator.

Apache Synapse ESB documentation:

* [`tech-catalog/esb/apache-synapse.md`](diffhunk://#diff-285eeadcd981dd4e52c751918b73f407ccb5989265d4eca113c012499e6e52b0R1-R88): Added comprehensive documentation for Apache Synapse ESB, including its key features, use cases, and an example configuration.

WSO2 Micro Integrator documentation:

* [`tech-catalog/esb/wso2-mi.md`](diffhunk://#diff-9d64f2f7b9abe827ee1d880014120ae94742882c8f0f019513e580dcc673ecbaR1-R87): Added comprehensive documentation for WSO2 Micro Integrator, including its key features, use cases, and an example configuration.