### PR TITLE
Fix Jekyll doc issues and update copy to clipboard button styles

### DIFF
--- a/docs/_includes/navigation.html
+++ b/docs/_includes/navigation.html
@@ -13,6 +13,8 @@
             </button>
         </div>
         {% endif %}
+
+        <!-- Logo -->
         <a class="navbar-brand p-0 me-0 me-lg-2" href="{{ site.baseurl }}/" aria-label="DailyDev">
          <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" class="d-block me-2" viewBox="0 0 688 528" role="img"><title>{{ site.title }}</title><path d="M334.232849,516.341553
  C312.860138,519.141724 291.830200,518.875732 270.946991,517.106323

--- a/docs/_sass/_clipboard-js.scss
+++ b/docs/_sass/_clipboard-js.scss
@@ -30,7 +30,7 @@
 .bd-clipboard,
 .bd-edit {
   position: relative;
-  display: none;
+  display: inline-block;
   float: right;
 
   + .highlight {

--- a/docs/_technologies/jekyll.md
+++ b/docs/_technologies/jekyll.md
@@ -409,12 +409,12 @@ all the variables set via the command line
 {{ site.collections | where: "label", "myCollection" | first }}
 ```
 
--`label`: name of the collection
--`docs`: array of documents in the collection
--`files`: array of static files in the collection
--`relative_directory`: path to the collection's source directory, relative to the site source
--`directory`: full path to the collection's source directory
--`output`: whether the collection's documents will be output as individual files
+- `label`: name of the collection
+- `docs`: array of documents in the collection
+- `files`: array of static files in the collection
+- `relative_directory`: path to the collection's source directory, relative to the site source
+- `directory`: full path to the collection's source directory
+- `output`: whether the collection's documents will be output as individual files
 
 Attributes accessible via each document in a collection:
 - `content`
@@ -461,54 +461,59 @@ Attributes accessible via each document in a collection:
 
 `_includes/`: partial html files reused in the above layout
 - `_includes/head.html`: head section of the site (stylesheets, scripts, meta tags)
-```html
-<!-- This file is used to include the header of the website -->
-<!--  Site metadata -->
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- browser tab title -->
-<title>
-    {% if page.url == "/" %}
-        {{ site.title }}
-    {% else %}
-        {{ site.title }} | {{ page.title }}
-    {% endif %}
-</title>
-<!-- Scripts / JS Files -------------------------------------------------------------------------------------------- -->
-<!-- Script for toggling theme/ color mode -->
-<script src="{{ '/assets/js/theme.js' | relative_url }}"></script>
-<!-- Stylesheets / CSS Files --------------------------------------------------------------------------------------- -->
-{% include stylesheet.html %}
-```
+
+  ```html
+  <!-- This file is used to include the header of the website -->
+  <!--  Site metadata -->
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- browser tab title -->
+  <title>
+      {% if page.url == "/" %}
+          {{ site.title }}
+      {% else %}
+          {{ site.title }} | {{ page.title }}
+      {% endif %}
+  </title>
+  <!-- Scripts / JS Files -------------------------------------------------------------------------------------------- -->
+  <!-- Script for toggling theme/ color mode -->
+  <script src="{{ '/assets/js/theme.js' | relative_url }}"></script>
+  <!-- Stylesheets / CSS Files --------------------------------------------------------------------------------------- -->
+  {% include stylesheet.html %}
+  ```
 
 - `_includes/stylesheet.html`: stylesheet list
-```html
-<!-- Stylesheets / CSS Files -->
-<!-- Bootswatch lumen bootstrap theme -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/lumen/bootstrap.min.css">
-<!-- custom CSS styles specific to the project:
-used alongside Bootstrap framework to provide additional customizations that are unique to the project -->
-<link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
-```
+
+  ```html
+  <!-- Stylesheets / CSS Files -->
+  <!-- Bootswatch lumen bootstrap theme -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/lumen/bootstrap.min.css">
+  <!-- custom CSS styles specific to the project:
+  used alongside Bootstrap framework to provide additional customizations that are unique to the project -->
+  <link rel="stylesheet" href="{{ '/assets/css/styles.css' | relative_url }}">
+  ```
 
 - `_includes/navigation.html`: menu bar navigation style
-```html
-<nav class="navbar navbar-expand-lg bg-primary sticky-top" data-bs-theme="dark">
-  .....
-</nav>
-```
+
+  ```html
+  <nav class="navbar navbar-expand-lg bg-primary sticky-top" data-bs-theme="dark">
+    .....
+  </nav>
+  ```
 
 - `_includes/svg-icons.html`: SVG icons list
-```html
-<svg xmlns="http://www.w3.org/2000/svg" class="d-none">
-  <symbol id="chevron-expand" viewBox="0 0 16 16">
-    <path fill-rule="evenodd" d="M3.646 9.146a.5.5 0 0 1 .708 0L8 12.793l3.646-3.647a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 0-.708zm0-2.292a.5.5 0 0 0 .708 0L8 3.207l3.646 3.647a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 0 0 0 .708z"></path>
-  </symbol>
-  .....
-</svg>
-```
+
+  ```html
+  <svg xmlns="http://www.w3.org/2000/svg" class="d-none">
+    <symbol id="chevron-expand" viewBox="0 0 16 16">
+      <path fill-rule="evenodd" d="M3.646 9.146a.5.5 0 0 1 .708 0L8 12.793l3.646-3.647a.5.5 0 0 1 .708.708l-4 4a.5.5 0 0 1-.708 0l-4-4a.5.5 0 0 1 0-.708zm0-2.292a.5.5 0 0 0 .708 0L8 3.207l3.646 3.647a.5.5 0 0 0 .708-.708l-4-4a.5.5 0 0 0-.708 0l-4 4a.5.5 0 0 0 0 .708z"></path>
+    </symbol>
+    .....
+  </svg>
+  ```
 
 `_includes/footer.html`: footer for the site
+
 ```html
 <footer class="bd-footer py-4 py-md-5 mt-5 bg-body-tertiary">
   .....
@@ -516,6 +521,7 @@ used alongside Bootstrap framework to provide additional customizations that are
 ```
 
 `_includes/scripts.html`: JS scripts list
+
 ```html
 <!-- JS Scripts -->
 <!-- Bootstrap JS and Popper.js CDN -->
@@ -536,23 +542,24 @@ collection items can be accessed with: `site.<COLLECTION_NAME>` variable
 - collection items/documents: @ `_<COLLECTION_NAME>` directory 
 - layout for items/individual documents: `_layouts/<COLLECTION_ITEM_COMMON_NAME>.html`
 - collection configurations in `_config.yaml`
-```yaml
-  collections:
-    <COLLECTION_NAME>:
-      output: true
-      permalink: /:collection/:name/
-      # name: document's base filename slugified: downcased and
-      #   every sequence of non-alphanumeric character (including spaces) replaced by a hyphen
-  defaults:
-    - scope:
-        path: ""
-        type: "<COLLECTION_NAME>"
-      values:
-        layout: "<LAYOUT_FOR_COLLECTION_ITEM>"
-        # other custom variables for collection items/docs
-        show_sidebar: true 
-        toc: true
- ```
+
+  ```yaml
+    collections:
+      <COLLECTION_NAME>:
+        output: true
+        permalink: /:collection/:name/
+        # name: document's base filename slugified: downcased and
+        #   every sequence of non-alphanumeric character (including spaces) replaced by a hyphen
+    defaults:
+      - scope:
+          path: ""
+          type: "<COLLECTION_NAME>"
+        values:
+          layout: "<LAYOUT_FOR_COLLECTION_ITEM>"
+          # other custom variables for collection items/docs
+          show_sidebar: true 
+          toc: true
+   ```
 
 
 # Liquid Filters
@@ -1044,16 +1051,16 @@ Using [allejo/jekyll-toc](https://github.com/allejo/jekyll-toc)
 - TOC is generated based on <h1> to <h6> headings in the markdown content
 
 `_includes/toc.html`: liquid template for generating TOC
-- `https://github.com/allejo/jekyll-toc/blob/master/_includes/toc.html`
+- [allejo/jekyll-toc:toc.html](https://github.com/allejo/jekyll-toc/blob/master/_includes/toc.html)
 
 `_sass/_toc.scss`: styles for the table of contents
-- https://github.com/twbs/bootstrap/blob/90acd33350e1356194a364595cb07b65f24bd611/site/assets/scss/_toc.scss
+- [twbs/bootstrap:_toc.scss](https://github.com/twbs/bootstrap/blob/90acd33350e1356194a364595cb07b65f24bd611/site/assets/scss/_toc.scss)
 
 `_sass/_layout.scss`: styles for the layout with TOC
-- https://github.com/twbs/bootstrap/blob/90acd33350e1356194a364595cb07b65f24bd611/site/assets/scss/_layout.scss
+- [twbs/bootstrap:_layout.scss](https://github.com/twbs/bootstrap/blob/90acd33350e1356194a364595cb07b65f24bd611/site/assets/scss/_layout.scss)
 
 `_sass/vendor/_rfs.scss`: styles for responsive font sizes
-- https://github.com/twbs/bootstrap/blob/90acd33350e1356194a364595cb07b65f24bd611/scss/vendor/_rfs.scss
+- [twbs/bootstrap:vendor/_rfs.scss](https://github.com/twbs/bootstrap/blob/90acd33350e1356194a364595cb07b65f24bd611/scss/vendor/_rfs.scss)
 
 `_sass/_mixins.scss`: import RFS mixins required for styles
 ```scss

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+show_sidebar: false
 ---
 
 # DailyDev 👩🏻‍💻🎯


### PR DESCRIPTION
# Fix Jekyll doc issues and update copy to clipboard button styles

## Details:

Related Issues
* #20 
* #19 


## Updates & Bug Fixes:

### Display Style Adjustments:
* [`docs/_sass/_clipboard-js.scss`](diffhunk://#diff-d9f072f094e562fa2f9d7184871753331f4eaa51234d9888db3cab5b02d23b7fL33-R33): Changed the display property of `.bd-clipboard` and `.bd-edit` from `none` to `inline-block` to ensure they are visible.

### Documentation Enhancements:
* [`docs/_technologies/jekyll.md`](diffhunk://#diff-35ce31bd70c9d2c23befe092dd22b0f4e7a44b7a60525988092b41b886cb9d0fR464): Added new lines to separate sections and improve readability in multiple places, including `_includes/head.html`, `_includes/stylesheet.html`, `_includes/navigation.html`, `_includes/svg-icons.html`, `_includes/footer.html`, and `_includes/scripts.html`. [[1]](diffhunk://#diff-35ce31bd70c9d2c23befe092dd22b0f4e7a44b7a60525988092b41b886cb9d0fR464) [[2]](diffhunk://#diff-35ce31bd70c9d2c23befe092dd22b0f4e7a44b7a60525988092b41b886cb9d0fR486) [[3]](diffhunk://#diff-35ce31bd70c9d2c23befe092dd22b0f4e7a44b7a60525988092b41b886cb9d0fR497-R505) [[4]](diffhunk://#diff-35ce31bd70c9d2c23befe092dd22b0f4e7a44b7a60525988092b41b886cb9d0fR516-R524) [[5]](diffhunk://#diff-35ce31bd70c9d2c23befe092dd22b0f4e7a44b7a60525988092b41b886cb9d0fR545)
* [`docs/_technologies/jekyll.md`](diffhunk://#diff-35ce31bd70c9d2c23befe092dd22b0f4e7a44b7a60525988092b41b886cb9d0fL1047-R1063): Updated links to use markdown format for better readability and consistency.

### Configuration Updates:
* [`docs/index.md`](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6R3): Added `show_sidebar: false` to the front matter to hide the sidebar on the index page.
